### PR TITLE
Update to //Remove All Magazines.

### DIFF
--- a/service_point/service_point_rearm.sqf
+++ b/service_point/service_point_rearm.sqf
@@ -30,7 +30,7 @@ if !([[[_costs select 0, _costs select 1]],0] call epoch_returnChange) then {
 	// remove all magazines
 	_magazines = _vehicle magazinesTurret _turret;
 	{
-		_vehicle removeMagazineTurret [_x, _turret];
+		_vehicle removeMagazineTurret [_ammo, _turret];
 	} forEach _magazines;
 	
 	// add magazines


### PR DESCRIPTION
When rearming a vehicle with multiple weapons i found that it would strip the ammo for all guns in the seat before rearming the gun i chose. Meaning i could only pull away from a service station with 1 weapon armed.

By changing '_vehicle addMagazineTurret [_x, _turret];' into '_vehicle addMagazineTurret [_ammo, _turret];'. The script only removes the magazines from the weapon being rearmed.

Originally it would remove ALL magazines from the turret when you rearm. Now it only removes the magazines that you are 'buying' and leaves any other guns in the turret as they were.

Only tested with a few vehicles. May need further testing.